### PR TITLE
Add local installer

### DIFF
--- a/install_local.sh
+++ b/install_local.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Check if root
+if [ "$UID" -eq 0 ]; then
+	echo ERROR!: The local installer is meant to be run by a user, not an administrative account \(root\)!
+	exit 1
+fi
+
+# Check if "usr" exists; copy to local prefix if it does
+if [ -d "usr" ]; then
+	# Modify desktop file to point to local references
+	sed -i "s|^\(Exec=\).*|\1$HOME/.local/bin/pipewire-config|" ./usr/share/applications/pipewireconfig.desktop
+
+	# Copy application files to local prefix
+	echo Copying application files...
+	rsync -auP usr/* "$HOME/.local/"
+	echo Finished copying application files!
+# Check if "pipewire-config" exists; update if it does
+elif [ -d "pipewire-config" ]; then
+	# Check if git is installed
+	if [ -x /usr/bin/git ]; then
+		echo Updating pipewire-config...
+		pushd pipewire-config
+		git pull
+		echo Finished updating pipewire-config!
+
+		# Modify desktop file to point to local references
+		sed -i "s|^\(Exec=\).*|\1$HOME/.local/bin/pipewire-config|" ./usr/share/applications/pipewireconfig.desktop
+
+		# Copy application files to local prefix
+		echo Copying application files...
+		rsync -auP usr/* "$HOME/.local/"
+		echo Finished copying application files!
+	else
+		echo "ERROR!: \`git\` must be installed, but it cannot be found."
+		exit 2
+	fi
+# Clone files if "usr" and "pipewire-config" both do not exist
+else
+	#Check if git is installed
+	if [ -x /usr/bin/git ]; then
+		echo Downloading application files...
+		git clone https://github.com/nickgirga/pipewire-config.git
+		echo Finished downloading application files...
+
+		# Modify desktop file to point to local references
+		sed -i "s|^\(Exec=\).*|\1$HOME/.local/bin/pipewire-config|" ./pipewire-config/usr/share/applications/pipewireconfig.desktop
+
+		# Copy application files to local prefix
+		echo Copying application files...
+		rsync -auP pipewire-config/usr/* "$HOME/.local/"
+		echo Finished copying application files!
+	else
+		echo "ERROR!: \`git\` must be installed, but it cannot be found."
+		exit 2
+	fi
+fi


### PR DESCRIPTION
I created an install script that does not require super user permissions to run or use. This is useful for people that choose to operate entirely in their user space. In fact, on my system (Fedora Kionite), this is really the most efficient and safest way to install and use this program. I figured it might be helpful for other people.

My repository has some slight improvements (minor bug fixes, documentation, screenshots, etc.). Feel free to check it out and snag whatever you want. I translated mine to English, so merge requests after this commit would probably get gross (which is why I chose to only merge the installer, something I created before translating.

Also, please add a license to the repository, so that contributors know exactly what they can and cannot do legally with your existing work. If you just need help deciding on a good license, you can use resources like [choosealicense.com](https://choosealicense.com/) to help you decide.